### PR TITLE
Fix for bug: No server side validation for “duration” field while cre…

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointmentscheduling/validator/AppointmentRequestValidator.java
+++ b/api/src/main/java/org/openmrs/module/appointmentscheduling/validator/AppointmentRequestValidator.java
@@ -41,7 +41,18 @@ public class AppointmentRequestValidator implements Validator {
             ValidationUtils.rejectIfEmpty(errors, "appointmentType", "appointmentscheduling.AppointmentRequest.emptyType");
             ValidationUtils.rejectIfEmpty(errors, "requestedOn", "appointmentscheduling.AppointmentRequest.emptyRequestedOn");
             ValidationUtils.rejectIfEmpty(errors, "status", "appointmentscheduling.AppointmentRequest.emptyStatus");
+            validateTimeFrame(appointmentRequest, errors);
+        }
+    }
 
+    private void validateTimeFrame(AppointmentRequest appointmentRequest, Errors errors) {
+        if (appointmentRequest.getMinTimeFrameValue() != null && appointmentRequest.getMaxTimeFrameValue() != null) {
+            if (appointmentRequest.getMinTimeFrameValue() <= 0
+                    || appointmentRequest.getMaxTimeFrameValue() <= 0
+                    || appointmentRequest.getMinTimeFrameValue() > Integer.MAX_VALUE
+                    || appointmentRequest.getMinTimeFrameValue() > Integer.MAX_VALUE) {
+                errors.rejectValue("appointmentRequest", "error.general");
+            }
         }
     }
 


### PR DESCRIPTION
**Vulnerability Name -** No server-side validation for “duration” field while creating a new appointment type.

**Description -** While creating a new appointment type, input field “duration” is validated on the client side for valid integer field but not on the server side because of which Numberformatexception is thrown with the complete stack trace for an invalid number for duration bypassed through ZAP.

**Fix -** We have added an additional validation on the server side for duration field to restrict invalid integer.