### PR TITLE
RA-1772: Fix stored xss in appointment scheduling

### DIFF
--- a/api/src/main/java/org/openmrs/module/appointmentscheduling/validator/AppointmentTypeValidator.java
+++ b/api/src/main/java/org/openmrs/module/appointmentscheduling/validator/AppointmentTypeValidator.java
@@ -18,6 +18,7 @@ import org.apache.commons.logging.LogFactory;
 import org.openmrs.annotation.Handler;
 import org.openmrs.module.appointmentscheduling.AppointmentType;
 import org.openmrs.module.appointmentscheduling.api.AppointmentService;
+import org.openmrs.web.WebUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.validation.Errors;
@@ -82,6 +83,9 @@ public class AppointmentTypeValidator implements Validator {
 		if (verifyIfNameHasMoreThan100Characters(appointmentType.getName())) {
 			errors.rejectValue("name", "appointmentscheduling.AppointmentType.longName.errorMessage");
 		}
+		if(verifyIfNameHasHtmlEncodableChars(appointmentType.getName())){
+			errors.rejectValue("name", "appointmentscheduling.AppointmentType.unsafeName.errorMessage");
+		}
 	}
 	
 	private boolean verifyIfNameHasMoreThan100Characters(String appointmentName) {
@@ -107,6 +111,13 @@ public class AppointmentTypeValidator implements Validator {
 	private boolean verifyIfDescriptionHasMoreThan1024Characters(String description) {
 		if (description != null) {
 			return (description.length() > 1024) ? true : false;
+		}
+		return false;
+	}
+
+	private boolean verifyIfNameHasHtmlEncodableChars(String appointmentName) {
+		if(appointmentName != null){
+			return !WebUtil.escapeHTML(appointmentName).equals(appointmentName);
 		}
 		return false;
 	}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -24,6 +24,7 @@ ${project.parent.artifactId}.AppointmentType.duration.errorMessage = Duration mu
 ${project.parent.artifactId}.AppointmentType.steps.details=Appointment Type Details
 ${project.parent.artifactId}.AppointmentType.nameDuplicated=Name is duplicated
 ${project.parent.artifactId}.AppointmentType.longName.errorMessage= Name must have less than 100 characters
+${project.parent.artifactId}.AppointmentType.unsafeName.errorMessage= Name must not have HTML characters
 ${project.parent.artifactId}.AppointmentType.description.errorMessage = Description must have less than 1024 characters
 
 ${project.parent.artifactId}.AppointmentBlock.manage.title=Provider Scheduling

--- a/api/src/test/java/org/openmrs/module/appointmentscheduling/validator/AppointmentTypeValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/appointmentscheduling/validator/AppointmentTypeValidatorTest.java
@@ -94,7 +94,17 @@ public class AppointmentTypeValidatorTest {
 		
 		Mockito.verify(errors).rejectValue("name", "appointmentscheduling.AppointmentType.longName.errorMessage");
 	}
-	
+
+	@Test
+	public void mustRejectAppointmentTypeNameWithXSS() throws Exception {
+		String evilName = "<script>alert(1)</script>";
+		AppointmentType appointmentTypeEvilName = new AppointmentType(evilName, "", 10);
+
+		appointmentTypeValidator.validate(appointmentTypeEvilName, errors);
+
+		Mockito.verify(errors).rejectValue("name", "appointmentscheduling.AppointmentType.unsafeName.errorMessage");
+	}
+
 	@Test
 	public void mustRejectAppointmentTypeDescriptionWithMoreThan1024Characters() throws Exception {
 		String longDescription = StringUtils.repeat("*", 1025);


### PR DESCRIPTION
**Why?**
Appointment scheduling is vulnerable to stored XSS as described here: https://talk.openmrs.org/t/responsible-vulnerability-disclosure/27899

**What Changed?**
Updated the service type validator so that it doesn't accept service names with HTML characters.

**Decisions Made**
It looks like we're using `bind-html-unsafe` angular directive in a few places in this module so that `<strong></strong>` tags can be dynamically injected. As such, I opted to sanitize inputs rather than outputs because sanitizing the outputs would likely break the dynamic HTML injection functionality.