### PR TITLE
AM-216 Properly map the sequences via hibernate

### DIFF
--- a/api/src/main/resources/Appointment.hbm.xml
+++ b/api/src/main/resources/Appointment.hbm.xml
@@ -7,7 +7,9 @@
 
 	<class name="Appointment" table="${project.parent.artifactId}_appointment">
 		<id name="appointmentId" type="int" column="appointment_id" unsaved-value="0">
-			<generator class="native" />
+			<generator class="native">
+				<param name="sequence">appointmentscheduling_appointment_appointment_id_seq</param>
+			</generator>
 		</id>
 		
 		<discriminator column="appointment_id" insert="false" />

--- a/api/src/main/resources/AppointmentBlock.hbm.xml
+++ b/api/src/main/resources/AppointmentBlock.hbm.xml
@@ -7,7 +7,9 @@
 
 	<class name="AppointmentBlock" table="${project.parent.artifactId}_appointment_block">
 		<id name="appointmentBlockId" type="int" column="appointment_block_id" unsaved-value="0">
-			<generator class="native" />
+			<generator class="native">
+				<param name="sequence">appointmentscheduling_appointment_bloc_appointment_block_id_seq</param>
+			</generator>
 		</id>
 		
 		<discriminator column="appointment_block_id" insert="false" />

--- a/api/src/main/resources/AppointmentBlock.hbm.xml
+++ b/api/src/main/resources/AppointmentBlock.hbm.xml
@@ -8,6 +8,9 @@
 	<class name="AppointmentBlock" table="${project.parent.artifactId}_appointment_block">
 		<id name="appointmentBlockId" type="int" column="appointment_block_id" unsaved-value="0">
 			<generator class="native">
+				<!-- Due to limit on max length of sequence on PostgreSQL, the table name gets sliced from the end
+				Original Sequence Name as Expected - appointmentscheduling_appointment_block_appointment_block_id_seq
+				Current Sequence Name for PostgreSQL - appointmentscheduling_appointment_bloc_appointment_block_id_seq -->
 				<param name="sequence">appointmentscheduling_appointment_bloc_appointment_block_id_seq</param>
 			</generator>
 		</id>

--- a/api/src/main/resources/AppointmentRequest.hbm.xml
+++ b/api/src/main/resources/AppointmentRequest.hbm.xml
@@ -8,6 +8,9 @@
     <class name="AppointmentRequest" table="appointmentscheduling_appointment_request">
         <id name="appointmentRequestId" type="int" column="appointment_request_id" unsaved-value="0">
 			<generator class="native">
+			<!-- Due to limit on max length of sequence on PostgreSQL, the table name gets sliced from the end
+				Original Sequence Name as Expected - appointmentscheduling_appointment_request_appointment_request_id_seq
+				Current Sequence Name for PostgreSQL - appointmentscheduling_appointment_re_appointment_request_id_seq -->
 				<param name="sequence">appointmentscheduling_appointment_re_appointment_request_id_seq</param>
 			</generator>
         </id>

--- a/api/src/main/resources/AppointmentRequest.hbm.xml
+++ b/api/src/main/resources/AppointmentRequest.hbm.xml
@@ -7,7 +7,9 @@
 
     <class name="AppointmentRequest" table="appointmentscheduling_appointment_request">
         <id name="appointmentRequestId" type="int" column="appointment_request_id" unsaved-value="0">
-            <generator class="native" />
+			<generator class="native">
+				<param name="sequence">appointmentscheduling_appointment_re_appointment_request_id_seq</param>
+			</generator>
         </id>
 
         <discriminator column="appointment_request_id" insert="false" />

--- a/api/src/main/resources/AppointmentStatusHistory.hbm.xml
+++ b/api/src/main/resources/AppointmentStatusHistory.hbm.xml
@@ -7,7 +7,9 @@
 
 	<class name="AppointmentStatusHistory" table="${project.parent.artifactId}_appointment_status_history">
 		<id name="appointmentStatusHistoryId" type="int" column="appointment_status_history_id" unsaved-value="0">
-			<generator class="native" />
+			<generator class="native">
+				<param name="sequence">appointmentscheduling_appoint_appointment_status_history_id_seq</param>
+			</generator>
 		</id>
 		
 		<discriminator column="appointment_status_history_id" insert="false" />

--- a/api/src/main/resources/AppointmentStatusHistory.hbm.xml
+++ b/api/src/main/resources/AppointmentStatusHistory.hbm.xml
@@ -8,6 +8,9 @@
 	<class name="AppointmentStatusHistory" table="${project.parent.artifactId}_appointment_status_history">
 		<id name="appointmentStatusHistoryId" type="int" column="appointment_status_history_id" unsaved-value="0">
 			<generator class="native">
+			<!-- Due to limit on max length of sequence on PostgreSQL, the table name gets sliced from the end
+				Original Sequence Name as Expected - appointmentscheduling_appointment_status_history_appointment_status_history_id_seq
+				Current Sequence Name for PostgreSQL - appointmentscheduling_appoint_appointment_status_history_id_seq -->
 				<param name="sequence">appointmentscheduling_appoint_appointment_status_history_id_seq</param>
 			</generator>
 		</id>

--- a/api/src/main/resources/AppointmentType.hbm.xml
+++ b/api/src/main/resources/AppointmentType.hbm.xml
@@ -7,7 +7,7 @@
 
 		<id name="appointmentTypeId" type="java.lang.Integer"	column="appointment_type_id" unsaved-value="0">
 			<generator class="native">
-				<param name="sequence">appointment_type_appointment_type_id_seq</param>
+				<param name="sequence">appointmentscheduling_appointment_type_appointment_type_id_seq</param>
 			</generator>
 		</id>
 		

--- a/api/src/main/resources/ProviderSchedule.hbm.xml
+++ b/api/src/main/resources/ProviderSchedule.hbm.xml
@@ -8,7 +8,7 @@
     <class name="ProviderSchedule" table="${project.parent.artifactId}_provider_schedule">
         <id name="providerScheduleId" type="int" column="provider_schedule_id" unsaved-value="0">
             <generator class="native">
-                <param name="sequence">provider_schedule_provider_schedule_id_seq</param>
+                <param name="sequence">appointmentscheduling_provider_schedul_provider_schedule_id_seq</param>
             </generator>
         </id>
 

--- a/api/src/main/resources/ProviderSchedule.hbm.xml
+++ b/api/src/main/resources/ProviderSchedule.hbm.xml
@@ -8,6 +8,9 @@
     <class name="ProviderSchedule" table="${project.parent.artifactId}_provider_schedule">
         <id name="providerScheduleId" type="int" column="provider_schedule_id" unsaved-value="0">
             <generator class="native">
+            	<!-- Due to limit on max length of sequence on PostgreSQL, the table name gets sliced from the end
+				Original Sequence Name as Expected - appointmentscheduling_provider_schedule_provider_schedule_id_seq
+				Current Sequence Name for PostgreSQL - appointmentscheduling_provider_schedul_provider_schedule_id_seq -->
                 <param name="sequence">appointmentscheduling_provider_schedul_provider_schedule_id_seq</param>
             </generator>
         </id>

--- a/api/src/main/resources/TimeSlot.hbm.xml
+++ b/api/src/main/resources/TimeSlot.hbm.xml
@@ -7,7 +7,9 @@
 
 	<class name="TimeSlot" table="${project.parent.artifactId}_time_slot">
 		<id name="timeSlotId" type="int" column="time_slot_id" unsaved-value="0">
-			<generator class="native" />
+			<generator class="native">
+				<param name="sequence">appointmentscheduling_time_slot_time_slot_id_seq</param>
+			</generator>
 		</id>
 		
 		<discriminator column="time_slot_id" insert="false" />


### PR DESCRIPTION
**Changes I made**
Mapped the sequences as generated in PostgreSQL db. 

**NOTE** - Due to a limit on the length of sequence name in PostgreSQL, at many places the table name gets sliced while generating sequence name. So, I have added the sequence names as generated in PostgreSQL db. 


**Link to ticket**
https://issues.openmrs.org/browse/AM-216